### PR TITLE
Bump up OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,9 +176,9 @@ AC_RUN_IFELSE(
 		case "$ssl_library_ver" in
 			101*)   ;; # 1.1.x
 			200*)   ;; # LibreSSL
-			300*)   ;; # OpenSSL development branch.
+			301*)   ;; # OpenSSL 3.1.x
 		        *)
-				AC_MSG_ERROR([OpenSSL >= 1.1.0 required (have "$ssl_library_ver")])
+				AC_MSG_ERROR([OpenSSL >= 3.1.x required (have "$ssl_library_ver")])
 		                ;;
 		esac
 		AC_MSG_RESULT([$ssl_library_ver])


### PR DESCRIPTION
All older versions (including 1.1.1, 1.1.0, 1.0.2, 1.0.0 and 0.9.8) are now out of support and should not be used. Users of these older versions are encouraged to upgrade to 3.1 or 3.0 as soon as possible.

Source: https://www.openssl.org/source/

Related PR: https://github.com/CSCfi/docker-emscripten-crypt4gh/pull/15